### PR TITLE
added main screen and navigation usable for more UI templates

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -62,4 +62,7 @@ dependencies {
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.4.0'
     androidTestImplementation "androidx.compose.ui:ui-test-junit4:$compose_version"
     debugImplementation "androidx.compose.ui:ui-tooling:$compose_version"
+
+    // navigation
+    implementation 'androidx.navigation:navigation-compose:2.4.0-alpha10'
 }

--- a/app/src/main/java/com/example/composeuitemplates/MainActivity.kt
+++ b/app/src/main/java/com/example/composeuitemplates/MainActivity.kt
@@ -3,19 +3,24 @@ package com.example.composeuitemplates
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
+import androidx.compose.material.ExperimentalMaterialApi
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Surface
+import androidx.navigation.compose.rememberNavController
+import com.example.composeuitemplates.mainscreen.Navigation
 import com.example.composeuitemplates.presentation.ChatScreen
 import com.example.composeuitemplates.ui.theme.ComposeUiTempletesTheme
 
 class MainActivity : ComponentActivity() {
+    @ExperimentalMaterialApi
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContent {
             ComposeUiTempletesTheme() {
                 // A surface container using the 'background' color from the theme
                 Surface(color = MaterialTheme.colors.background) {
-                    ChatScreen()
+                    val navController = rememberNavController()
+                    Navigation(navController)
                 }
             }
         }

--- a/app/src/main/java/com/example/composeuitemplates/mainscreen/MainScreen.kt
+++ b/app/src/main/java/com/example/composeuitemplates/mainscreen/MainScreen.kt
@@ -1,0 +1,60 @@
+package com.example.composeuitemplates.mainscreen
+
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.ExperimentalMaterialApi
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Surface
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import androidx.navigation.NavController
+
+data class ScreenNames(
+    val name: String,
+    val route: String
+)
+
+val screens = listOf(
+    ScreenNames("Chat Screen", Screen.ChatScreen.route)
+)
+
+@ExperimentalMaterialApi
+@Composable
+fun MainScreen(navController: NavController){
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(16.dp)
+    ){
+        LazyColumn {
+            items(screens){screen ->
+                Item(name = screen.name){
+                    navController.navigate(screen.route)
+                }
+                Spacer(modifier = Modifier.height(16.dp))
+            }
+        }
+    }
+}
+
+
+@ExperimentalMaterialApi
+@Composable
+fun Item(
+    name: String,
+    onclick: () -> Unit
+){
+    Surface(
+        modifier = Modifier.fillMaxWidth(),
+        shape = MaterialTheme.shapes.medium,
+        onClick = onclick
+    ) {
+        Text(
+            text = name,
+            modifier = Modifier.padding(16.dp)
+        )
+    }
+}

--- a/app/src/main/java/com/example/composeuitemplates/mainscreen/Navigation.kt
+++ b/app/src/main/java/com/example/composeuitemplates/mainscreen/Navigation.kt
@@ -1,0 +1,25 @@
+package com.example.composeuitemplates.mainscreen
+
+import androidx.compose.material.ExperimentalMaterialApi
+import androidx.compose.runtime.Composable
+import androidx.navigation.NavHostController
+import androidx.navigation.compose.NavHost
+import androidx.navigation.compose.composable
+import com.example.composeuitemplates.presentation.ChatScreen
+
+@ExperimentalMaterialApi
+@Composable
+fun Navigation(navController: NavHostController){
+    NavHost(
+        navController = navController,
+        startDestination = Screen.MainScreen.route
+    ){
+        composable(route = Screen.MainScreen.route){
+            MainScreen(navController = navController)
+        }
+        composable(route = Screen.ChatScreen.route){
+            ChatScreen(navController = navController)
+        }
+
+    }
+}

--- a/app/src/main/java/com/example/composeuitemplates/mainscreen/Screen.kt
+++ b/app/src/main/java/com/example/composeuitemplates/mainscreen/Screen.kt
@@ -1,0 +1,6 @@
+package com.example.composeuitemplates.mainscreen
+
+sealed class Screen(val route: String) {
+    object MainScreen: Screen("Main_screen")
+    object ChatScreen: Screen("Chat_screen")
+}

--- a/app/src/main/java/com/example/composeuitemplates/presentation/ChatScreen.kt
+++ b/app/src/main/java/com/example/composeuitemplates/presentation/ChatScreen.kt
@@ -25,6 +25,7 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import androidx.navigation.NavController
 import com.example.composeuitemplates.R
 
 data class Chat(
@@ -49,7 +50,7 @@ const val profile = R.drawable.gojo
 const val isOnline = true
 
 @Composable
-fun ChatScreen() {
+fun ChatScreen(navController: NavController) {
     Column(
         modifier = Modifier.fillMaxSize(),
         verticalArrangement = Arrangement.SpaceBetween

--- a/app/src/main/res/values-night/themes.xml
+++ b/app/src/main/res/values-night/themes.xml
@@ -10,7 +10,7 @@
         <item name="colorSecondaryVariant">@color/teal_200</item>
         <item name="colorOnSecondary">@color/black</item>
         <!-- Status bar color. -->
-        <item name="android:statusBarColor" tools:targetApi="l">@color/white</item>
+        <item name="android:statusBarColor" tools:targetApi="l">@android:color/transparent</item>
         <!-- Customize your theme here. -->
     </style>
 </resources>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -10,7 +10,7 @@
         <item name="colorSecondaryVariant">@color/teal_700</item>
         <item name="colorOnSecondary">@color/black</item>
         <!-- Status bar color. -->
-        <item name="android:statusBarColor" tools:targetApi="l">@color/white</item>
+        <item name="android:statusBarColor" tools:targetApi="l">@android:color/transparent</item>
         <!-- Customize your theme here. -->
     </style>
 


### PR DESCRIPTION
Issue: https://github.com/Hiten24/Compose-Ui-Templates/issues/3
- Main Screen:
<img src="https://user-images.githubusercontent.com/57827233/135726845-80327da9-da48-4234-8809-0ea19551ea86.png" width="220">
- Chat screen:
<img src="https://user-images.githubusercontent.com/57827233/135726866-4748e845-bb4f-4779-921a-b67d29427cee.png" width="220">