### PR TITLE
Text field hint bug Resolved

### DIFF
--- a/app/src/main/java/com/example/composeuitemplates/presentation/ChatScreen.kt
+++ b/app/src/main/java/com/example/composeuitemplates/presentation/ChatScreen.kt
@@ -9,16 +9,15 @@ import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.BasicTextField
-import androidx.compose.material.Card
-import androidx.compose.material.Icon
-import androidx.compose.material.MaterialTheme
-import androidx.compose.material.Text
+import androidx.compose.material.*
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.painter.Painter
 import androidx.compose.ui.res.painterResource
@@ -27,6 +26,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.navigation.NavController
 import com.example.composeuitemplates.R
+import kotlin.reflect.KProperty
 
 data class Chat(
     val message: String,
@@ -94,7 +94,9 @@ fun TopBarSection(
             Image(
                 painter = profile,
                 contentDescription = null,
-                modifier = Modifier.size(42.dp).clip(CircleShape)
+                modifier = Modifier
+                    .size(42.dp)
+                    .clip(CircleShape)
             )
 
             Spacer(modifier = Modifier.width(8.dp))
@@ -115,7 +117,9 @@ fun ChatSection(
     modifier: Modifier = Modifier
 ) {
     LazyColumn(
-        modifier = modifier.fillMaxWidth().padding(16.dp),
+        modifier = modifier
+            .fillMaxWidth()
+            .padding(16.dp),
     ) {
         items(chats) { chat ->
             MessageItem(
@@ -134,40 +138,33 @@ fun MessageSection() {
         modifier = Modifier
             .fillMaxWidth(),
         backgroundColor = Color.White,
-        elevation = 4.dp
+        elevation = 10.dp
     ) {
-        Row(
-            modifier = Modifier.padding(16.dp),
-            horizontalArrangement = Arrangement.SpaceBetween,
-            verticalAlignment = Alignment.CenterVertically
-        ) {
-            Box(
-                modifier = Modifier
-                    .background(MaterialTheme.colors.surface, shape = RoundedCornerShape(25.dp))
-                    .height(50.dp)
-                    .weight(1f),
-                contentAlignment = Alignment.Center
-            ) {
-                BasicTextField(
+                OutlinedTextField(
+                    placeholder = {
+                        Text("Message..")
+                    },
                     value = message.value,
                     onValueChange = {
                         message.value = it
                     },
+                    shape = RoundedCornerShape(25.dp),
+                    trailingIcon = {
+                        Icon(
+                            painter = painterResource(id = R.drawable.ic_send, ),
+                            contentDescription = null,
+                            tint = MaterialTheme.colors.primary,
+                            modifier = Modifier.clickable {
+                                chats.add(Chat(message.value, "10:00 PM", true))
+                                message.value = ""
+                            }
+                        )
+
+                    },
                     modifier = Modifier
                         .fillMaxWidth()
-                        .padding(horizontal = 16.dp),
+                        .padding(6.dp),
                 )
-            }
-            Spacer(modifier = Modifier.width(16.dp))
-            Icon(
-                painter = painterResource(id = R.drawable.ic_send),
-                contentDescription = null,
-                Modifier.clickable {
-                    chats.add(Chat(message.value, "10:00 PM", true))
-                    message.value = ""
-                }
-            )
-        }
     }
 }
 


### PR DESCRIPTION
https://github.com/Hiten24/Compose-Ui-Templates/issues/4
<img src="https://cdn.discordapp.com/attachments/755768937156837449/894505648845377566/Screenshot_20211004-141546.jpg" width="200">
Added a hint in the text field and visual changes like shifting send button in text field and border were added.