### PR TITLE
Modifications made to adjust as per keyboard toggle status

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -12,6 +12,7 @@
         <activity
             android:name="com.example.composeuitemplates.MainActivity"
             android:exported="true"
+            android:windowSoftInputMode="adjustResize"
             android:label="@string/app_name"
             android:theme="@style/Theme.ComposeUiTempletes.NoActionBar">
             <intent-filter>

--- a/app/src/main/java/com/example/composeuitemplates/presentation/chat_ui/ChatScreen.kt
+++ b/app/src/main/java/com/example/composeuitemplates/presentation/chat_ui/ChatScreen.kt
@@ -140,31 +140,31 @@ fun MessageSection() {
         backgroundColor = Color.White,
         elevation = 10.dp
     ) {
-                OutlinedTextField(
-                    placeholder = {
-                        Text("Message..")
-                    },
-                    value = message.value,
-                    onValueChange = {
-                        message.value = it
-                    },
-                    shape = RoundedCornerShape(25.dp),
-                    trailingIcon = {
-                        Icon(
-                            painter = painterResource(id = R.drawable.ic_send, ),
-                            contentDescription = null,
-                            tint = MaterialTheme.colors.primary,
-                            modifier = Modifier.clickable {
-                                chats.add(Chat(message.value, "10:00 PM", true))
-                                message.value = ""
-                            }
-                        )
-
-                    },
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .padding(6.dp),
+        OutlinedTextField(
+            placeholder = {
+                Text("Message..")
+            },
+            value = message.value,
+            onValueChange = {
+                message.value = it
+            },
+            shape = RoundedCornerShape(25.dp),
+            trailingIcon = {
+                Icon(
+                    painter = painterResource(id = R.drawable.ic_send, ),
+                    contentDescription = null,
+                    tint = MaterialTheme.colors.primary,
+                    modifier = Modifier.clickable {
+                        chats.add(Chat(message.value, "10:00 PM", true))
+                        message.value = ""
+                    }
                 )
+
+            },
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(6.dp),
+        )
     }
 }
 


### PR DESCRIPTION
 https://github.com/Hiten24/Compose-Ui-Templates/issues/9

Enabled the option so that the text the text field does not hide behind keyboard but adjusts itself according to keyboard's state.

<img src="https://user-images.githubusercontent.com/67424137/135919389-05dddf71-af66-4180-b0f0-23ccb5cf8d7f.png" width="300">
